### PR TITLE
Changing time datatype so it is a float rather than a decimal

### DIFF
--- a/src/Storm.GoogleAnalytics.Reporting/Impl/GoogleAnalyticsService.cs
+++ b/src/Storm.GoogleAnalytics.Reporting/Impl/GoogleAnalyticsService.cs
@@ -146,8 +146,9 @@ namespace Storm.GoogleAnalytics.Reporting.Impl
                 case "double":
                     return typeof(double);
                 case "currency":
+                    return typeof (decimal);
                 case "time":
-                    return typeof(decimal);
+                    return typeof(float);
                 default:
                     if (gaColumn.Name.ToLowerInvariant().Equals(GaMetadata.WithPrefix(GaMetadata.Dimensions.Time.Date)))
                     {


### PR DESCRIPTION
When trying this out I found that Average Time on Site can be returned as a float (i.e. as 1.9427047E7) rather than a decimal.
