### PR TITLE
Adding X509KeyStorageFlags.MachineKeySet when loading X509Certificate

### DIFF
--- a/src/Storm.GoogleAnalytics.Reporting/Configuration/Impl/GoogleAnalyticsServiceConfigurer.cs
+++ b/src/Storm.GoogleAnalytics.Reporting/Configuration/Impl/GoogleAnalyticsServiceConfigurer.cs
@@ -83,7 +83,7 @@ namespace Storm.GoogleAnalytics.Reporting.Configuration.Impl
         {
             if (!string.IsNullOrWhiteSpace(keyFile) && File.Exists(keyFile))
             {
-                WithServiceAccountCertificate(new X509Certificate2(keyFile, password, X509KeyStorageFlags.Exportable));
+                WithServiceAccountCertificate(new X509Certificate2(keyFile, password, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.MachineKeySet));
             }
             else
             {


### PR DESCRIPTION
To add support for Azure Websites - see http://blog.tylerdoerksen.com/2013/08/23/pfx-certificate-files-and-windows-azure-websites/ for details
