### PR TITLE
Improving handling of the "MaxResults" parameter

### DIFF
--- a/src/Storm.GoogleAnalytics.Reporting/Configuration/Impl/GoogleAnalyticsRequestConfigurer.cs
+++ b/src/Storm.GoogleAnalytics.Reporting/Configuration/Impl/GoogleAnalyticsRequestConfigurer.cs
@@ -141,7 +141,7 @@ namespace Storm.GoogleAnalytics.Reporting.Configuration.Impl
             Filter = filter;
             return this;
         }
-        
+
         public IGoogleAnalyticsRequestConfigurer SortBy(string field, bool isDescending = false)
         {
             if (string.IsNullOrWhiteSpace(Sort))
@@ -171,19 +171,28 @@ namespace Storm.GoogleAnalytics.Reporting.Configuration.Impl
 
         IGoogleAnalyticsRequestCustomConfigurer IGoogleAnalyticsRequestCustomConfigurer.Segment(string value)
         {
-            Segment = value;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                Segment = value;
+            }
             return this;
         }
 
         IGoogleAnalyticsRequestCustomConfigurer IGoogleAnalyticsRequestCustomConfigurer.Filter(string value)
         {
-            Filter = value;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                Filter = value;
+            }
             return this;
         }
 
         IGoogleAnalyticsRequestCustomConfigurer IGoogleAnalyticsRequestCustomConfigurer.Sort(string value)
         {
-            Sort = value;
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                Sort = value;
+            }
             return this;
         }
 

--- a/src/Storm.GoogleAnalytics.Reporting/Impl/GoogleAnalyticsService.cs
+++ b/src/Storm.GoogleAnalytics.Reporting/Impl/GoogleAnalyticsService.cs
@@ -42,7 +42,7 @@ namespace Storm.GoogleAnalytics.Reporting.Impl
             _serviceConfiguration = config.Build();
         }
 
-        
+
         public IGoogleAnalyticsResponse Query(
             Func<IGoogleAnalyticsRequestConfigurerProfileId, IGoogleAnalyticsRequestConfigurerProfileId> configurer)
         {
@@ -78,17 +78,21 @@ namespace Storm.GoogleAnalytics.Reporting.Impl
 
                     while (data.NextLink != null && data.Rows != null)
                     {
+                        if (requestConfig.MaxResults < 10000 && data.Rows.Count <= requestConfig.MaxResults)
+                        {
+                            break;
+                        }
                         gRequest.StartIndex = (gRequest.StartIndex ?? 1) + data.Rows.Count;
                         data = await gRequest.ExecuteAsync();
                         dt.Merge(ToDataTable(data));
                     }
-                    return new GoogleAnalyticsResponse(requestConfig, 
+                    return new GoogleAnalyticsResponse(requestConfig,
                         true,
                         new GoogleAnalyticsDataResponse(dt, data.ContainsSampledData.GetValueOrDefault(false)));
                 }
                 catch (Exception ex)
                 {
-                    return new GoogleAnalyticsResponse(requestConfig, 
+                    return new GoogleAnalyticsResponse(requestConfig,
                         false, errorResponse: new GoogleAnalyticsErrorResponse(ex.Message, ex));
                 }
             }


### PR DESCRIPTION
If the MaxResults parameter is set to anything less than the maximum (10000), then we shouldn't fetch all the results and instead only return the number specified in MaxResults.

Currently MaxResults currently behaves as a sort of "rowsPerPage" property - however, this commit makes it actually a hard limit on how many rows are fetched meaning that decreasing the MaxResults actually improves peformance.
